### PR TITLE
Fix execve path absolute

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: vde-vasc <vde-vasc@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/02/14 04:14:17 by vde-vasc          #+#    #+#             */
-/*   Updated: 2023/02/28 16:22:34 by vde-vasc         ###   ########.fr       */
+/*   Updated: 2023/03/01 20:12:25 by vde-vasc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,11 +23,17 @@
 # include <sys/ioctl.h>
 # include "../libft/libft.h"
 
+# define TRUE 1
+# define FALSE 0
+
 typedef struct s_cmd
 {
 	char	*input;
+
 	char	**env;
 	int		env_size;
+
+	char	**exec;
 
 	char	**path;
 
@@ -37,6 +43,7 @@ typedef struct s_cmd
 void	create_env(t_cmd *cmd, char **envp);
 void	builtin_env(t_cmd *cmd);
 void	builtin_exit(t_cmd *cmd);
+void	env_path(t_cmd *cmd);
 void	execution(t_cmd *exec);
 
 #endif

--- a/src/env.c
+++ b/src/env.c
@@ -6,11 +6,30 @@
 /*   By: vde-vasc <vde-vasc@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/02/14 16:30:08 by vde-vasc          #+#    #+#             */
-/*   Updated: 2023/02/28 02:40:40 by vde-vasc         ###   ########.fr       */
+/*   Updated: 2023/03/01 18:40:20 by vde-vasc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
+
+void	env_path(t_cmd *cmd)
+
+{
+	int		i;
+	char	*tmp;
+
+	i = 0;
+	while (cmd->env[i])
+	{
+		if (!ft_strncmp(cmd->env[i], "PATH", 4))
+		{
+			tmp = ft_strdup(cmd->env[i]);
+			cmd->path = ft_split(tmp + 5, ':');
+			break ;
+		}
+		i++;
+	}
+}
 
 static int	env_size(char **str)
 
@@ -35,4 +54,5 @@ void	create_env(t_cmd *cmd, char **envp)
 		return ;
 	while (++i < cmd->env_size)
 		cmd->env[i] = ft_strdup(envp[i]);
+	env_path(cmd);
 }

--- a/src/exec.c
+++ b/src/exec.c
@@ -6,24 +6,46 @@
 /*   By: vde-vasc <vde-vasc@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/02/28 02:43:16 by vde-vasc          #+#    #+#             */
-/*   Updated: 2023/02/28 16:20:34 by vde-vasc         ###   ########.fr       */
+/*   Updated: 2023/03/01 19:52:03 by vde-vasc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/minishell.h"
 
-void	execution(t_cmd *exec)
+int	check_command(t_cmd *cmd)
 
 {
-	int	pid;
+	int		i;
+	char	*full_path;
+
+	full_path = ft_strdup(cmd->exec[0]);
+	i = 0;
+	while (cmd->path[i])
+	{
+		if (access(full_path, F_OK | X_OK) == 0)
+		{
+			cmd->exec[0] = ft_strdup(full_path);
+			free(full_path);
+			execve(cmd->exec[0], cmd->exec, cmd->env);
+			return (TRUE);
+		}
+		free(full_path);
+		full_path = ft_strjoin(cmd->path[i], "/");
+		full_path = ft_strjoin(full_path, cmd->exec[0]);
+		i++;
+	}
+	return (FALSE);
+}
+
+void	execution(t_cmd *cmd)
+
+{
+	int		pid;
 
 	pid = fork();
-	exec->path = ft_split(exec->input, ' ');
+	cmd->exec = ft_split(cmd->input, ' ');
 	if (pid == 0)
-	{
-		execve(exec->path[0], exec->path, exec->env);
-		exit(0);
-	}
+		check_command(cmd);
 	else
 		wait(0);
 }


### PR DESCRIPTION

Agora consigo usar todos os comandos do terminal, menos alguns builtin (cd por exemplo) sem precisar botar o path absoluto.